### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,21 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm run build
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ This repository contains a minimal Vue 3 project configured with Webpack and Typ
 
 - `npm run dev` - start a development server with hot module replacement
 - `npm run build` - build the project for production
+
+## GitHub Pages
+
+This repository is configured with a GitHub Actions workflow that automatically builds the project and publishes the contents of the `dist` directory to the `gh-pages` branch. After enabling GitHub Pages in the repository settings and selecting the `gh-pages` branch, the site will be available online.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for gh-pages
- document GitHub Pages setup in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846447eda9083298e2b5fbcb006d0ca