### PR TITLE
Add navigation and writer page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "vue3-webpack-starter",
       "version": "1.0.0",
       "dependencies": {
-        "vue": "^3.4.5"
+        "quill": "^2.0.3",
+        "vue": "^3.4.5",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "css-loader": "^6.9.1",
@@ -763,6 +765,12 @@
         "@vue/compiler-dom": "3.5.16",
         "@vue/shared": "3.5.16"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.16",
@@ -2171,6 +2179,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -3110,6 +3124,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -3558,6 +3591,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/parchment": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3824,6 +3863,41 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quill": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "lodash-es": "^4.17.21",
+        "parchment": "^3.0.0",
+        "quill-delta": "^5.1.0"
+      },
+      "engines": {
+        "npm": ">=8.2.3"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/quill/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -4926,6 +5000,21 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vue-style-loader": {

--- a/package.json
+++ b/package.json
@@ -7,19 +7,21 @@
     "build": "webpack --config webpack.config.js"
   },
   "dependencies": {
-    "vue": "^3.4.5"
+    "quill": "^2.0.3",
+    "vue": "^3.4.5",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
-    "webpack": "^5.91.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1",
-    "vue-loader": "^17.2.0",
-    "vue-style-loader": "^4.1.3",
     "css-loader": "^6.9.1",
+    "html-webpack-plugin": "^5.5.3",
     "sass": "^1.73.0",
     "sass-loader": "^13.3.2",
     "ts-loader": "^9.5.1",
-    "html-webpack-plugin": "^5.5.3"
+    "typescript": "^5.4.0",
+    "vue-loader": "^17.2.0",
+    "vue-style-loader": "^4.1.3",
+    "webpack": "^5.91.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,11 @@
 <template>
   <div id="app">
-    <h1>Hello Vue 3 + TypeScript</h1>
+    <nav class="nav">
+      <router-link to="/">首页</router-link>
+      <router-link to="/writer">Writer</router-link>
+      <router-link to="/playground">Playground</router-link>
+    </nav>
+    <router-view />
   </div>
 </template>
 
@@ -13,4 +18,13 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.nav {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  background: #eee;
+}
+.nav a.router-link-exact-active {
+  font-weight: bold;
+}
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue';
 import App from './App.vue';
+import router from './router';
 import './styles.scss';
 
-createApp(App).mount('#app');
+createApp(App).use(router).mount('#app');

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="home">
+    <canvas ref="canvas" class="snow-canvas"></canvas>
+    <h1>Home</h1>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted, ref } from 'vue';
+
+interface Snowflake {
+  x: number;
+  y: number;
+  r: number;
+  vy: number;
+  alpha: number;
+}
+
+export default defineComponent({
+  name: 'Home',
+  setup() {
+    const canvas = ref<HTMLCanvasElement | null>(null);
+    const flakes: Snowflake[] = [];
+    let ctx: CanvasRenderingContext2D | null = null;
+    let width = 0;
+    let height = 0;
+
+    const createFlake = (x: number, y: number) => {
+      flakes.push({
+        x,
+        y,
+        r: Math.random() * 3 + 1,
+        vy: Math.random() * 1 + 0.5,
+        alpha: Math.random() * 0.5 + 0.5
+      });
+    };
+
+    const update = () => {
+      if (!ctx) return;
+      ctx.clearRect(0, 0, width, height);
+      for (let i = flakes.length - 1; i >= 0; i--) {
+        const f = flakes[i];
+        f.y += f.vy;
+        if (f.y > height) {
+          flakes.splice(i, 1);
+          continue;
+        }
+        ctx.globalAlpha = f.alpha;
+        ctx.beginPath();
+        ctx.arc(f.x, f.y, f.r, 0, Math.PI * 2);
+        ctx.fillStyle = '#fff';
+        ctx.fill();
+      }
+      requestAnimationFrame(update);
+    };
+
+    onMounted(() => {
+      if (canvas.value) {
+        ctx = canvas.value.getContext('2d');
+        const resize = () => {
+          width = window.innerWidth;
+          height = window.innerHeight;
+          canvas.value!.width = width;
+          canvas.value!.height = height;
+        };
+        resize();
+        window.addEventListener('resize', resize);
+        canvas.value.addEventListener('mousemove', (e) => {
+          for (let i = 0; i < 5; i++) {
+            createFlake(e.clientX, e.clientY);
+          }
+        });
+        update();
+      }
+    });
+
+    return { canvas };
+  }
+});
+</script>
+
+<style scoped>
+.home {
+  position: relative;
+  overflow: hidden;
+  height: 100vh;
+}
+.snow-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+}
+</style>

--- a/src/pages/Playground.vue
+++ b/src/pages/Playground.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="playground">
+    <h1>Playground</h1>
+    <p>Coming soon...</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'Playground'
+});
+</script>
+
+<style scoped>
+.playground {
+  padding: 1rem;
+}
+</style>

--- a/src/pages/Writer.vue
+++ b/src/pages/Writer.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="writer">
+    <div id="editor" class="editor"></div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted } from 'vue';
+import Quill from 'quill';
+import 'quill/dist/quill.snow.css';
+
+export default defineComponent({
+  name: 'Writer',
+  setup() {
+    onMounted(() => {
+      new Quill('#editor', { theme: 'snow' });
+    });
+  }
+});
+</script>
+
+<style scoped>
+.editor {
+  height: 400px;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,17 @@
+import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router';
+import Home from '@/pages/Home.vue';
+import Writer from '@/pages/Writer.vue';
+import Playground from '@/pages/Playground.vue';
+
+const routes: Array<RouteRecordRaw> = [
+  { path: '/', name: 'Home', component: Home },
+  { path: '/writer', name: 'Writer', component: Writer },
+  { path: '/playground', name: 'Playground', component: Playground }
+];
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes
+});
+
+export default router;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,13 @@ module.exports = {
         exclude: /node_modules/,
       },
       {
+        test: /\.css$/,
+        use: [
+          'vue-style-loader',
+          'css-loader'
+        ],
+      },
+      {
         test: /\.scss$/,
         use: [
           'vue-style-loader',


### PR DESCRIPTION
## Summary
- add vue-router and Quill dependencies
- create router with Home, Writer and Playground routes
- add navigation bar in App.vue
- add snowflake canvas animation for Home
- integrate Quill editor in Writer page
- add placeholder Playground page
- handle CSS files in webpack config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846481dd058832999b77b2dd1800002