### PR TITLE
Fix canvas visibility and remove scrollbars

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div id="app" class="app">
     <nav class="nav">
       <router-link to="/">首页</router-link>
       <router-link to="/writer">Writer</router-link>
@@ -18,6 +18,12 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
 .nav {
   display: flex;
   gap: 1rem;

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -64,6 +64,10 @@ export default defineComponent({
           canvas.value!.height = height;
         };
         resize();
+        // create some initial snowflakes so the effect is visible immediately
+        for (let i = 0; i < 100; i++) {
+          createFlake(Math.random() * width, Math.random() * height);
+        }
         window.addEventListener('resize', resize);
         canvas.value.addEventListener('mousemove', (e) => {
           for (let i = 0; i < 5; i++) {
@@ -83,7 +87,7 @@ export default defineComponent({
 .home {
   position: relative;
   overflow: hidden;
-  height: 100vh;
+  flex: 1;
 }
 .snow-canvas {
   position: absolute;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,9 +1,15 @@
 $primary-color: #42b983;
 
-body {
+html, body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+#app {
+  height: 100%;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- prevent page from overflowing by styling the root layout
- allow Home page to flex and remove fixed height
- start snowflakes right away so the canvas animation is visible

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68464f9710b083299e906bbea770c114