### PR TITLE
Add IndexedDB document saving to writer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vue3-webpack-starter",
       "version": "1.0.0",
       "dependencies": {
+        "idb": "^8.0.3",
         "quill": "^2.0.3",
         "vue": "^3.4.5",
         "vue-router": "^4.5.1"
@@ -2779,6 +2780,12 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/immutable": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "webpack --config webpack.config.js --mode production"
   },
   "dependencies": {
+    "idb": "^8.0.3",
     "quill": "^2.0.3",
     "vue": "^3.4.5",
     "vue-router": "^4.5.1"

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,39 @@
+import { openDB, DBSchema } from 'idb';
+
+interface WriterDB extends DBSchema {
+  documents: {
+    key: number;
+    value: {
+      id?: number;
+      title: string;
+      content: any;
+    };
+    indexes: { 'by-title': string };
+  };
+}
+
+const dbPromise = openDB<WriterDB>('writer-db', 1, {
+  upgrade(db) {
+    const store = db.createObjectStore('documents', { keyPath: 'id', autoIncrement: true });
+    store.createIndex('by-title', 'title');
+  }
+});
+
+export async function getAllDocs() {
+  const db = await dbPromise;
+  const docs = await db.getAll('documents');
+  return docs.map(d => ({ id: d.id as number, title: d.title }));
+}
+
+export async function getDoc(id: number) {
+  const db = await dbPromise;
+  return db.get('documents', id);
+}
+
+export async function saveDoc(doc: { id?: number; title: string; content: any }) {
+  const db = await dbPromise;
+  const tx = db.transaction('documents', 'readwrite');
+  const id = await tx.store.put(doc);
+  await tx.done;
+  return id as number;
+}

--- a/src/pages/Writer.vue
+++ b/src/pages/Writer.vue
@@ -1,26 +1,106 @@
 <template>
   <div class="writer">
-    <div id="editor" class="editor"></div>
+    <div class="sidebar">
+      <input v-model="search" placeholder="搜索" class="search" />
+      <ul class="file-list">
+        <li v-for="doc in filteredDocs" :key="doc.id">
+          <button @click="loadDoc(doc.id)">{{ doc.title }}</button>
+        </li>
+      </ul>
+    </div>
+    <div class="editor-container">
+      <input v-model="title" placeholder="标题" class="title-input" />
+      <div id="editor" class="editor"></div>
+      <button @click="save">保存</button>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted } from 'vue';
+import { defineComponent, onMounted, ref, computed } from 'vue';
 import Quill from 'quill';
 import 'quill/dist/quill.snow.css';
+import { getAllDocs, getDoc, saveDoc } from '@/db';
 
 export default defineComponent({
   name: 'Writer',
   setup() {
-    onMounted(() => {
-      new Quill('#editor', { theme: 'snow' });
+    const title = ref('');
+    const search = ref('');
+    const docs = ref<Array<{ id: number; title: string }>>([]);
+    const currentId = ref<number | null>(null);
+    let quill: Quill;
+
+    const loadDocs = async () => {
+      docs.value = await getAllDocs();
+    };
+
+    const filteredDocs = computed(() => {
+      return docs.value.filter(d =>
+        d.title.toLowerCase().includes(search.value.toLowerCase())
+      );
     });
+
+    const loadDoc = async (id: number) => {
+      const doc = await getDoc(id);
+      if (doc) {
+        title.value = doc.title;
+        quill.setContents(doc.content);
+        currentId.value = id;
+      }
+    };
+
+    const save = async () => {
+      const id = await saveDoc({
+        id: currentId.value ?? undefined,
+        title: title.value || '未命名',
+        content: quill.getContents()
+      });
+      currentId.value = id;
+      await loadDocs();
+    };
+
+    onMounted(async () => {
+      quill = new Quill('#editor', { theme: 'snow' });
+      await loadDocs();
+    });
+
+    return { title, search, filteredDocs, loadDoc, save };
   }
 });
 </script>
 
 <style scoped>
+.writer {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+}
+.sidebar {
+  width: 200px;
+  border-right: 1px solid #ddd;
+  padding-right: 1rem;
+}
+.editor-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
 .editor {
   height: 400px;
+}
+.file-list {
+  list-style: none;
+  padding: 0;
+}
+.file-list li {
+  margin-bottom: 0.5rem;
+}
+.title-input,
+.search {
+  width: 100%;
+  padding: 0.25rem;
+  box-sizing: border-box;
 }
 </style>


### PR DESCRIPTION
## Summary
- add idb dependency
- create simple IndexedDB helper
- enhance writer page with title input, file list search and document load/save

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846517656d08329b3205e54feb544a8